### PR TITLE
Updating the "main" to point to the built JS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,15 @@
   "version": "0.0.3",
   "description": "Wraps Jasmine 1.x matchers for use with Jasmine 2",
   "homepage": "https://github.com/testdouble/jasmine-matcher-wrapper",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/testdouble/jasmine-matcher-wrapper.git"
+  },
   "author": {
     "name": "Justin Searls",
     "company": "Test Double, LLC"
   },
-  "main": "main.js",
+  "main": "dist/jasmine-matcher-wrapper.js",
   "dependencies": {
     "coffee-script": "~ 1.6.3",
     "minijasminenode": "~0.2.7"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "name": "Justin Searls",
     "company": "Test Double, LLC"
   },
-  "main": "dist/jasmine-matcher-wrapper.js",
+  "main": "main.js",
+  "browser": "dist/jasmine-matcher-wrapper.js",
   "dependencies": {
     "coffee-script": "~ 1.6.3",
     "minijasminenode": "~0.2.7"


### PR DESCRIPTION
This makes bundling via Browserify a TON easier than the coffee path that main.js takes.  Plus, if you are delivering the JS, might as well have consumers use it directly.

While I was in there, I added the "repository" field so that npmjs.org will link to the source properly when the module gets published.